### PR TITLE
ensuring {} is returned even if no entities of that types are present connects #16

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,16 @@ setInterval(() => {
   for (const k of Object.keys(data)) {
     const ch = channels[k];
     if (ch) {
-      ch.send({ data: JSON.stringify(data[k]) });
+      const currentState = data[k];
+      for (const envName in currentState) {
+        // ensure that env state has all types present for consistency
+        const env = currentState[envName];
+        env.gateway = env.gateway || {};
+        env.workspace = env.workspace || {};
+        env['sls-api'] = env['sls-api'] || {};
+        env['kubeless-fn'] = env['kubeless-fn'] || {};
+      }
+      ch.send({ data: JSON.stringify(currentState) });
     }
   }
 }, 3000);


### PR DESCRIPTION
see #16 

deployed on staging 

even if no gateways of functions are present state will contain `{}` instead of undefined  